### PR TITLE
Improve CI and add PDF report

### DIFF
--- a/.github/workflows/data-analytics-ci.yml
+++ b/.github/workflows/data-analytics-ci.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.11"
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -43,6 +44,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.11"
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -64,6 +66,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.11"
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/data-analytics-ci.yml
+++ b/.github/workflows/data-analytics-ci.yml
@@ -31,8 +31,8 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with unittest and record test coverage
       run: |
-        python3 -m coverage run -m unittest test.py
-        coverage report -m
+        python3 -m coverage run -m unittest test.py | tee test_results.txt
+        coverage report -m | tee coverage.txt
 
   linting:
 
@@ -53,8 +53,8 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --max-complexity=10 --statistics --ignore=E501
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics | tee linting.txt
+        flake8 . --count --max-complexity=10 --statistics --ignore=E501 | tee -m linting.txt
 
   type-checking:
 
@@ -70,8 +70,34 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install mypy types-requests
+        pip install mypy types-requests types-fpdf2
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Type checking with mypy
       run: |
-        python3 -m mypy .
+        python3 -m mypy . | tee type_checking.txt
+
+  generate-pdf-report:
+
+    runs-on: ubuntu-latest
+    needs: [testing-and-coverage, linting, type-checking]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install fpdf2
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Generate PDF report
+      run: |
+        python3 -m generate_pdf_report.py
+    - name: Upload PDF report as a GitHub artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: data-analytics-testing-report
+        path: testing_report.pdf

--- a/.github/workflows/data-analytics-ci.yml
+++ b/.github/workflows/data-analytics-ci.yml
@@ -30,6 +30,7 @@ jobs:
         pip install coverage
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with unittest and record test coverage
+      continue-on-error: true
       run: |
         set -o pipefail
         python3 -m coverage run -m unittest test.py | tee test_results.txt
@@ -62,6 +63,7 @@ jobs:
         pip install flake8
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
+      continue-on-error: true
       run: |
         set -o pipefail
         # stop the build if there are Python syntax errors or undefined names
@@ -90,6 +92,7 @@ jobs:
         pip install mypy types-requests types-fpdf2
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Type checking with mypy
+      continue-on-error: true
       run: |
         set -o pipefail
         python3 -m mypy . | tee type_checking.txt

--- a/.github/workflows/data-analytics-ci.yml
+++ b/.github/workflows/data-analytics-ci.yml
@@ -34,6 +34,16 @@ jobs:
         set -o pipefail
         python3 -m coverage run -m unittest test.py | tee test_results.txt
         coverage report -m | tee coverage.txt
+    - name: Upload test results as a GitHub artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: test_results_incomplete
+        path: test_results.txt
+    - name: Upload coverage as a GitHub artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage_incomplete
+        path: coverage.txt
 
   linting:
 
@@ -57,6 +67,11 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics | tee linting.txt
         flake8 . --count --max-complexity=10 --statistics --ignore=E501 | tee -a linting.txt
+    - name: Upload linting results as a GitHub artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: linting_incomplete
+        path: linting.txt
 
   type-checking:
 
@@ -78,6 +93,11 @@ jobs:
       run: |
         set -o pipefail
         python3 -m mypy . | tee type_checking.txt
+    - name: Upload type checking as a GitHub artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: type_checking_incomplete
+        path: type_checking.txt
 
   generate-pdf-report:
 
@@ -97,6 +117,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install fpdf2
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Download results from previous jobs
+      uses: actions/download-artifact@v4
     - name: Generate PDF report
       run: |
         python3 generate_pdf_report.py

--- a/.github/workflows/data-analytics-ci.yml
+++ b/.github/workflows/data-analytics-ci.yml
@@ -30,17 +30,18 @@ jobs:
         pip install coverage
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with unittest and record test coverage
-      continue-on-error: true
       run: |
         set -o pipefail
         python3 -m coverage run -m unittest test.py | tee test_results.txt
         coverage report -m | tee coverage.txt
     - name: Upload test results as a GitHub artifact
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: test_results_incomplete
         path: test_results.txt
     - name: Upload coverage as a GitHub artifact
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: coverage_incomplete
@@ -63,13 +64,13 @@ jobs:
         pip install flake8
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
-      continue-on-error: true
       run: |
         set -o pipefail
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics | tee linting.txt
         flake8 . --count --max-complexity=10 --statistics --ignore=E501 | tee -a linting.txt
     - name: Upload linting results as a GitHub artifact
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: linting_incomplete
@@ -92,11 +93,11 @@ jobs:
         pip install mypy types-requests types-fpdf2
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Type checking with mypy
-      continue-on-error: true
       run: |
         set -o pipefail
         python3 -m mypy . | tee type_checking.txt
     - name: Upload type checking as a GitHub artifact
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: type_checking_incomplete

--- a/.github/workflows/data-analytics-ci.yml
+++ b/.github/workflows/data-analytics-ci.yml
@@ -31,6 +31,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with unittest and record test coverage
       run: |
+        set -o pipefail
         python3 -m coverage run -m unittest test.py | tee test_results.txt
         coverage report -m | tee coverage.txt
 
@@ -52,6 +53,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
+        set -o pipefail
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics | tee linting.txt
         flake8 . --count --max-complexity=10 --statistics --ignore=E501 | tee -a linting.txt
@@ -74,6 +76,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Type checking with mypy
       run: |
+        set -o pipefail
         python3 -m mypy . | tee type_checking.txt
 
   generate-pdf-report:
@@ -96,7 +99,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Generate PDF report
       run: |
-        python3 -m generate_pdf_report.py
+        python3 generate_pdf_report.py
     - name: Upload PDF report as a GitHub artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/data-analytics-ci.yml
+++ b/.github/workflows/data-analytics-ci.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics | tee linting.txt
-        flake8 . --count --max-complexity=10 --statistics --ignore=E501 | tee -m linting.txt
+        flake8 . --count --max-complexity=10 --statistics --ignore=E501 | tee -a linting.txt
 
   type-checking:
 
@@ -80,6 +80,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: [testing-and-coverage, linting, type-checking]
+    if: always()
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # Qubit_data_analytics
 
 ![Pipeline](https://github.com/pokemon47/Qubit_data_analytics/actions/workflows/data-analytics-ci.yml/badge.svg)
+
+## Testing Report
+
+To download the latest testing report PDF, go to the "Actions" tab of the
+repository, click on the latest workflow run, and scroll down to Artifacts.
+
+The testing report PDF should be contained inside the artifact file named
+**data-analytics-testing-report**. The other artifact files contain incomplete
+data from various jobs in the pipeline.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Qubit_data_analytics
+
+![Pipeline](https://github.com/pokemon47/Qubit_data_analytics/actions/workflows/data-analytics-ci.yml/badge.svg)
+
+[![Data Analytics Testing Report](https://img.shields.io/badge/Artifact-Download-blue)](https://github.com/pokemon47/Qubit_data_analytics/actions/runs/${GITHUB_RUN_ID}/artifacts/data-analytics-testing-report)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # Qubit_data_analytics
 
 ![Pipeline](https://github.com/pokemon47/Qubit_data_analytics/actions/workflows/data-analytics-ci.yml/badge.svg)
-
-[![Data Analytics Testing Report](https://img.shields.io/badge/Artifact-Download-blue)](https://github.com/pokemon47/Qubit_data_analytics/actions/runs/${GITHUB_RUN_ID}/artifacts/data-analytics-testing-report)

--- a/generate_pdf_report.py
+++ b/generate_pdf_report.py
@@ -49,7 +49,7 @@ pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
 
 pdf.set_font("courier", size=12)
 try:
-    with open("test_results.txt", "r") as test_results:
+    with open("test_results_incomplete/test_results.txt", "r") as test_results:
         lines = test_results.readlines()
 
         for line in lines:
@@ -71,7 +71,7 @@ pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
 
 pdf.set_font("courier", size=12)
 try:
-    with open("coverage.txt", "r") as coverage_report:
+    with open("coverage_incomplete/coverage.txt", "r") as coverage_report:
         lines = coverage_report.readlines()
 
         for line in lines:
@@ -89,7 +89,7 @@ pdf.cell(text="Our code has been linted with flake8 to ensure conformity to PEP-
          new_x="LMARGIN", new_y="NEXT")
 
 try:
-    with open("linting.txt", "r") as linting:
+    with open("linting_incomplete/linting.txt", "r") as linting:
         lines = linting.readlines()
 
         if len(lines) == 2 and lines[0].rstrip('\n') == "0" and lines[1].rstrip('\n') == "0":
@@ -129,7 +129,7 @@ pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
 
 pdf.set_font("courier", size=12)
 try:
-    with open("type_checking.txt", "r") as type_checking:
+    with open("type_checking_incomplete/type_checking.txt", "r") as type_checking:
         lines = type_checking.readlines()
 
         if not lines[0].startswith("Success"):

--- a/generate_pdf_report.py
+++ b/generate_pdf_report.py
@@ -21,6 +21,7 @@ def pass_or_fail(boolean: bool):
     else:
         return "FAILING"
 
+
 # Set up PDF
 pdf = fpdf.FPDF()
 pdf.set_title(f"{PDF_TITLE} - {current_time}")
@@ -42,7 +43,8 @@ pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
 pdf.set_font("helvetica", size=15, style="B")
 pdf.cell(text="Unit Tests", new_x="LMARGIN", new_y="NEXT")
 pdf.set_font("helvetica", size=12)
-pdf.cell(text=f"Our functions and routes have been tested with the {TEST_FRAMEWORK} test framework. Here are the results:", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(
+    text=f"Our functions and routes have been tested with the {TEST_FRAMEWORK} test framework. Here are the results:", new_x="LMARGIN", new_y="NEXT")
 pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
 
 pdf.set_font("courier", size=12)
@@ -53,16 +55,18 @@ try:
         for line in lines:
             pdf.multi_cell(w=0, text=f"{line}", new_x="LMARGIN", new_y="NEXT")
 
-            if not "passed" in line:
+            if "passed" not in line:
                 unit_tests_pass = False
 except FileNotFoundError:
-    pdf.cell(text="ERROR: Unit test results could not be found", new_x="LMARGIN", new_y="NEXT")
+    pdf.cell(text="ERROR: Unit test results could not be found",
+             new_x="LMARGIN", new_y="NEXT")
 
     unit_tests_pass = False
 
 pdf.set_font("helvetica", size=12)
 pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
-pdf.cell(text=f"Our unit tests currently have the following coverage:", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text="Our unit tests currently have the following coverage:",
+         new_x="LMARGIN", new_y="NEXT")
 pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
 
 pdf.set_font("courier", size=12)
@@ -73,35 +77,42 @@ try:
         for line in lines:
             pdf.multi_cell(w=0, text=f"{line}", new_x="LMARGIN", new_y="NEXT")
 except FileNotFoundError:
-    pdf.cell(text="ERROR: Coverage report could not be found", new_x="LMARGIN", new_y="NEXT")
+    pdf.cell(text="ERROR: Coverage report could not be found",
+             new_x="LMARGIN", new_y="NEXT")
 
 # Add section for linting
 pdf.set_font("helvetica", size=15, style="B")
 pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
 pdf.cell(text="Linting", new_x="LMARGIN", new_y="NEXT")
 pdf.set_font("helvetica", size=12)
-pdf.cell(text=f"Our code has been linted with flake8 to ensure conformity to PEP-8 guidelines.", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text="Our code has been linted with flake8 to ensure conformity to PEP-8 guidelines.",
+         new_x="LMARGIN", new_y="NEXT")
 
 try:
     with open("linting.txt", "r") as linting:
         lines = linting.readlines()
 
         if len(lines) == 2 and lines[0].rstrip('\n') == "0" and lines[1].rstrip('\n') == "0":
-            pdf.cell(text=f"The linting checks have passed, so our code is fully PEP-8 compliant.", new_x="LMARGIN", new_y="NEXT")
+            pdf.cell(text="The linting checks have passed, so our code is fully PEP-8 compliant.",
+                     new_x="LMARGIN", new_y="NEXT")
         else:
-            pdf.cell(text=f"The linting checks have failed, with the following errors:", new_x="LMARGIN", new_y="NEXT")
+            pdf.cell(text="The linting checks have failed, with the following errors:",
+                     new_x="LMARGIN", new_y="NEXT")
             pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
             pdf.set_font("courier", size=12)
 
             for line in lines:
-                pdf.multi_cell(w=0, text=f"{line}", new_x="LMARGIN", new_y="NEXT")
+                pdf.multi_cell(w=0, text=f"{line}",
+                               new_x="LMARGIN", new_y="NEXT")
 
             linting_pass = False
 except FileNotFoundError:
-    pdf.cell(text=f"The linting checks have failed, with the following errors:", new_x="LMARGIN", new_y="NEXT")
+    pdf.cell(text="The linting checks have failed, with the following errors:",
+             new_x="LMARGIN", new_y="NEXT")
     pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
     pdf.set_font("courier", size=12)
-    pdf.cell(text="ERROR: Linting results could not be found", new_x="LMARGIN", new_y="NEXT")
+    pdf.cell(text="ERROR: Linting results could not be found",
+             new_x="LMARGIN", new_y="NEXT")
 
     linting_pass = False
 
@@ -110,8 +121,10 @@ pdf.set_font("helvetica", size=15, style="B")
 pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
 pdf.cell(text="Type Checking", new_x="LMARGIN", new_y="NEXT")
 pdf.set_font("helvetica", size=12)
-pdf.cell(text=f"Since Python is dynamically typed, we used mypy to ensure type safety.", new_x="LMARGIN", new_y="NEXT")
-pdf.cell(text=f"Here are the results of our type checking:", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text="Since Python is dynamically typed, we used mypy to ensure type safety.",
+         new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text="Here are the results of our type checking:",
+         new_x="LMARGIN", new_y="NEXT")
 pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
 
 pdf.set_font("courier", size=12)
@@ -125,7 +138,8 @@ try:
         for line in lines:
             pdf.multi_cell(w=0, text=f"{line}", new_x="LMARGIN", new_y="NEXT")
 except FileNotFoundError:
-    pdf.cell(text="ERROR: Type checking results could not be found", new_x="LMARGIN", new_y="NEXT")
+    pdf.cell(text="ERROR: Type checking results could not be found",
+             new_x="LMARGIN", new_y="NEXT")
 
     type_checking_pass = False
 
@@ -138,12 +152,17 @@ pdf.set_font("helvetica", size=12)
 
 overall_pass = unit_tests_pass and linting_pass and type_checking_pass
 
-pdf.cell(text=f"Overall our tests are {pass_or_fail(overall_pass)}.", new_x="LMARGIN", new_y="NEXT")
-pdf.cell(text=f"The final results for each type of testing are as follows:", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(
+    text=f"Overall our tests are {pass_or_fail(overall_pass)}.", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text="The final results for each type of testing are as follows:",
+         new_x="LMARGIN", new_y="NEXT")
 pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
-pdf.cell(text=f"Unit Tests: {pass_or_fail(unit_tests_pass)}", new_x="LMARGIN", new_y="NEXT")
-pdf.cell(text=f"Linting: {pass_or_fail(linting_pass)}", new_x="LMARGIN", new_y="NEXT")
-pdf.cell(text=f"Type Checking: {pass_or_fail(type_checking_pass)}", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=f"Unit Tests: {pass_or_fail(unit_tests_pass)}",
+         new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=f"Linting: {pass_or_fail(linting_pass)}",
+         new_x="LMARGIN", new_y="NEXT")
+pdf.cell(
+    text=f"Type Checking: {pass_or_fail(type_checking_pass)}", new_x="LMARGIN", new_y="NEXT")
 
 # Generate the PDF using the provided information
 pdf.output("testing_report.pdf")

--- a/generate_pdf_report.py
+++ b/generate_pdf_report.py
@@ -1,0 +1,149 @@
+# Generates a PDF report for use in the GitHub CI/CD pipeline
+
+import fpdf
+import datetime
+
+# Set constants and variables
+PDF_TITLE = "Qubit Data Analytics: Testing report"
+TEST_FRAMEWORK = "unittest"
+current_time = datetime.datetime.now().ctime()
+
+unit_tests_pass = True
+linting_pass = True
+type_checking_pass = True
+
+
+# Function which converts a boolean value (true / false) into a string
+# (PASSING or FAILING)
+def pass_or_fail(boolean: bool):
+    if boolean:
+        return "PASSING"
+    else:
+        return "FAILING"
+
+# Set up PDF
+pdf = fpdf.FPDF()
+pdf.set_title(f"{PDF_TITLE} - {current_time}")
+pdf.add_page()
+
+# PDF title and time of creation
+pdf.set_font("helvetica", size=25, style="BU")
+pdf.cell(text=f"{PDF_TITLE}", center=True, new_x="LMARGIN", new_y="NEXT")
+pdf.set_font("helvetica", size=12, style="I")
+pdf.cell(text=f"{current_time}", center=True, new_x="LMARGIN", new_y="NEXT")
+
+# Create some empty space
+pdf.set_font("helvetica", size=12)
+pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+
+# Add section for unit tests and coverage
+pdf.set_font("helvetica", size=15, style="B")
+pdf.cell(text="Unit Tests", new_x="LMARGIN", new_y="NEXT")
+pdf.set_font("helvetica", size=12)
+pdf.cell(text=f"Our functions and routes have been tested with the {TEST_FRAMEWORK} test framework. Here are the results:", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+
+pdf.set_font("courier", size=12)
+try:
+    with open("test_results.txt", "r") as test_results:
+        lines = test_results.readlines()
+
+        for line in lines:
+            pdf.multi_cell(w=0, text=f"{line}", new_x="LMARGIN", new_y="NEXT")
+
+            if not "passed" in line:
+                unit_tests_pass = False
+except FileNotFoundError:
+    pdf.cell(text="ERROR: Unit test results could not be found", new_x="LMARGIN", new_y="NEXT")
+
+    unit_tests_pass = False
+
+pdf.set_font("helvetica", size=12)
+pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=f"Our unit tests currently have the following coverage:", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+
+pdf.set_font("courier", size=12)
+try:
+    with open("coverage.txt", "r") as coverage_report:
+        lines = coverage_report.readlines()
+
+        for line in lines:
+            pdf.multi_cell(w=0, text=f"{line}", new_x="LMARGIN", new_y="NEXT")
+except FileNotFoundError:
+    pdf.cell(text="ERROR: Coverage report could not be found", new_x="LMARGIN", new_y="NEXT")
+
+# Add section for linting
+pdf.set_font("helvetica", size=15, style="B")
+pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text="Linting", new_x="LMARGIN", new_y="NEXT")
+pdf.set_font("helvetica", size=12)
+pdf.cell(text=f"Our code has been linted with flake8 to ensure conformity to PEP-8 guidelines.", new_x="LMARGIN", new_y="NEXT")
+
+try:
+    with open("linting.txt", "r") as linting:
+        lines = linting.readlines()
+
+        if len(lines) == 2 and lines[0].rstrip('\n') == "0" and lines[1].rstrip('\n') == "0":
+            pdf.cell(text=f"The linting checks have passed, so our code is fully PEP-8 compliant.", new_x="LMARGIN", new_y="NEXT")
+        else:
+            pdf.cell(text=f"The linting checks have failed, with the following errors:", new_x="LMARGIN", new_y="NEXT")
+            pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+            pdf.set_font("courier", size=12)
+
+            for line in lines:
+                pdf.multi_cell(w=0, text=f"{line}", new_x="LMARGIN", new_y="NEXT")
+
+            linting_pass = False
+except FileNotFoundError:
+    pdf.cell(text=f"The linting checks have failed, with the following errors:", new_x="LMARGIN", new_y="NEXT")
+    pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+    pdf.set_font("courier", size=12)
+    pdf.cell(text="ERROR: Linting results could not be found", new_x="LMARGIN", new_y="NEXT")
+
+    linting_pass = False
+
+# Add section for type checking
+pdf.set_font("helvetica", size=15, style="B")
+pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text="Type Checking", new_x="LMARGIN", new_y="NEXT")
+pdf.set_font("helvetica", size=12)
+pdf.cell(text=f"Since Python is dynamically typed, we used mypy to ensure type safety.", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=f"Here are the results of our type checking:", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+
+pdf.set_font("courier", size=12)
+try:
+    with open("type_checking.txt", "r") as type_checking:
+        lines = type_checking.readlines()
+
+        if not lines[0].startswith("Success"):
+            type_checking_pass = False
+
+        for line in lines:
+            pdf.multi_cell(w=0, text=f"{line}", new_x="LMARGIN", new_y="NEXT")
+except FileNotFoundError:
+    pdf.cell(text="ERROR: Type checking results could not be found", new_x="LMARGIN", new_y="NEXT")
+
+    type_checking_pass = False
+
+# Add section for overall results
+# Add section for type checking
+pdf.set_font("helvetica", size=15, style="B")
+pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text="Overall Results", new_x="LMARGIN", new_y="NEXT")
+pdf.set_font("helvetica", size=12)
+
+overall_pass = unit_tests_pass and linting_pass and type_checking_pass
+
+pdf.cell(text=f"Overall our tests are {pass_or_fail(overall_pass)}.", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=f"The final results for each type of testing are as follows:", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=f"Unit Tests: {pass_or_fail(unit_tests_pass)}", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=f"Linting: {pass_or_fail(linting_pass)}", new_x="LMARGIN", new_y="NEXT")
+pdf.cell(text=f"Type Checking: {pass_or_fail(type_checking_pass)}", new_x="LMARGIN", new_y="NEXT")
+
+# Generate the PDF using the provided information
+pdf.output("testing_report.pdf")

--- a/generate_pdf_report.py
+++ b/generate_pdf_report.py
@@ -6,7 +6,8 @@ import datetime
 # Set constants and variables
 PDF_TITLE = "Qubit Data Analytics: Testing report"
 TEST_FRAMEWORK = "unittest"
-current_time = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=11))).ctime()
+current_time = datetime.datetime.now(
+    datetime.timezone(datetime.timedelta(hours=11))).ctime()
 
 unit_tests_pass = True
 linting_pass = True
@@ -23,7 +24,7 @@ def pass_or_fail(boolean: bool):
 
 
 # Set up PDF
-pdf = fpdf.FPDF()
+pdf = fpdf.FPDF(orientation="L")
 pdf.set_title(f"{PDF_TITLE} - {current_time}")
 pdf.add_page()
 
@@ -121,9 +122,7 @@ pdf.set_font("helvetica", size=15, style="B")
 pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
 pdf.cell(text="Type Checking", new_x="LMARGIN", new_y="NEXT")
 pdf.set_font("helvetica", size=12)
-pdf.cell(text="Since Python is dynamically typed, we used mypy to ensure type safety.",
-         new_x="LMARGIN", new_y="NEXT")
-pdf.cell(text="Here are the results of our type checking:",
+pdf.cell(text="Since Python is dynamically typed, we used mypy to ensure type safety. Here are the results of our type checking:",
          new_x="LMARGIN", new_y="NEXT")
 pdf.cell(text=" ", new_x="LMARGIN", new_y="NEXT")
 

--- a/generate_pdf_report.py
+++ b/generate_pdf_report.py
@@ -6,7 +6,7 @@ import datetime
 # Set constants and variables
 PDF_TITLE = "Qubit Data Analytics: Testing report"
 TEST_FRAMEWORK = "unittest"
-current_time = datetime.datetime.now().ctime()
+current_time = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=11))).ctime()
 
 unit_tests_pass = True
 linting_pass = True


### PR DESCRIPTION
This pull request adds an automatically generated PDF report to the CI pipeline. Every time the pipeline is run, it generates a new PDF report, which can be downloaded by going to Actions, clicking on a run, and downloading the testing report artifact.

The PDF report contains a summary of all the tests that were run during the pipeline and their results.

Additionally, there are a couple of other minor changes in this pull request:
- The CI pipeline now caches Python dependencies, so it should be (slightly) faster
- The README.md file has been updated with a sticker that shows whether the latest pipeline run (on `main`) passed or failed

It would be nice to somehow add a link to the testing report to the README as well, but I am not sure how to do this because the testing report link is dynamic and changes every time the pipeline runs.