### PR TITLE
Fix the PDF report sometimes saying unit tests failed when they passed

### DIFF
--- a/generate_pdf_report.py
+++ b/generate_pdf_report.py
@@ -56,7 +56,7 @@ try:
         for line in lines:
             pdf.multi_cell(w=0, text=f"{line}", new_x="LMARGIN", new_y="NEXT")
 
-            if "passed" not in line:
+            if "fail" in line.lower():
                 unit_tests_pass = False
 except FileNotFoundError:
     pdf.cell(text="ERROR: Unit test results could not be found",


### PR DESCRIPTION
This merge request makes a minor change to the PDF report generated by the Data Analytics pipeline, to (hopefully) fix a bug where it sometimes says unit tests failed even when they passed.